### PR TITLE
Expand personal site content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,7 @@
-## Welcome to GitHub Pages
+# Marat Khairullin
 
-You can use the [editor on GitHub](https://github.com/xmm/xmm.github.io/edit/main/README.md) to maintain and preview the content for your website in Markdown files.
-
-Whenever you commit to this repository, GitHub Pages will run [Jekyll](https://jekyllrb.com/) to rebuild the pages in your site, from the content in your Markdown files.
-
-### Markdown
-
-Markdown is a lightweight and easy-to-use syntax for styling your writing. It includes conventions for
-
-```markdown
-Syntax highlighted code block
-
-# Header 1
-## Header 2
-### Header 3
-
-- Bulleted
-- List
-
-1. Numbered
-2. List
-
-**Bold** and _Italic_ and `Code` text
-
-[Link](url) and ![Image](src)
-```
-
-For more details see [GitHub Flavored Markdown](https://guides.github.com/features/mastering-markdown/).
-
-### Jekyll Themes
-
-Your Pages site will use the layout and styles from the Jekyll theme you have selected in your [repository settings](https://github.com/xmm/xmm.github.io/settings/pages). The name of this theme is saved in the Jekyll `_config.yml` configuration file.
-
-### Support or Contact
-
-Having trouble with Pages? Check out our [documentation](https://docs.github.com/categories/github-pages-basics/) or [contact support](https://support.github.com/contact) and we’ll help you sort it out.
+This repository contains the source for my personal site hosted with **GitHub Pages**.
+The site uses the [Minimal](https://pages-themes.github.io/minimal/) theme and
+shares details of my experience at Global Intellect Service, Acronis and other
+projects. It also links to my pet project
+[jvmcraft](https://github.com/xmm/jvmcraft) and provides contact information.

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,4 @@
-theme: jekyll-theme-slate
+theme: jekyll-theme-minimal
+title: Marat Khairullin
+description: Personal site with CV and pet projects
+

--- a/index.md
+++ b/index.md
@@ -1,0 +1,43 @@
+---
+layout: default
+---
+
+# Marat Khairullin
+
+**Senior Software Engineer - UDS**
+
+Kazan, Tatarstan, Russia
+
+Software architect with over 20 years experience in analysis, design, development, testing and implementation of various projects. Skilled at team collaboration while working independently in remote environments. I'm a very hard-working, results-oriented and responsible person.
+
+## Experience
+
+### Global Intellect Service (Sep 2019 - Present)
+Backend developer focusing on the loyalty platform [UDS](https://uds.app/) – a
+customer engagement application that provides digital loyalty programs,
+marketing tools and analytics. I design and maintain microservices written in
+Java, Groovy and Kotlin with PostgreSQL, RabbitMQ, Spring WebFlux, Ratpack and
+Docker.
+
+### Acronis (Dec 2015 - Apr 2019)
+Backend developer for **Acronis Software-Defined Infrastructure**. I designed
+and implemented Python/Flask services powering the web management console,
+integrated them with the storage and virtualization stack, optimized
+PostgreSQL queries and contributed to deployment automation on Linux.
+
+### EZ Menu (May 2015 - Dec 2015)
+Team Lead and architect of a restaurant business startup. Responsibilities included team coordination, requirements analysis, backend and database design, and REST API development using Flask, PostgreSQL, Swagger, Stripe and AWS.
+
+## Education
+
+**Kazan State University** – Bachelor's Degree in Applied Mathematics and Cybernetics.
+
+## Pet Projects
+
+[jvmcraft](https://github.com/xmm/jvmcraft) – a personal project exploring
+how the Java Virtual Machine works and experimenting with bytecode tools.
+
+## Contact
+
+[GitHub](https://github.com/xmm) •
+[LinkedIn](https://www.linkedin.com/in/xmarat/)


### PR DESCRIPTION
## Summary
- add title and description to the config
- expand experience and pet project details on index page
- link to LinkedIn and jvmcraft
- update README to reflect contents

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686adb6c47588326a52705ca95c1d2c9